### PR TITLE
Add support for Laravel 12 and Monolog 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     "require": {
         "php": "^8.1",
         "monolog/monolog": "^3.0",
-        "illuminate/support": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0"
     },
     "autoload": {
         "psr-4": {
             "Enigma\\": "src/"
         }
-    }
+    },
+    "version": "v2.1.0"
 }


### PR DESCRIPTION
This PR updates the `GoogleChatHandler` to be compatible with **Laravel 12** and **Monolog 3.x**, addressing the following error encountered during the Laravel 12 upgrade:

### Testing
- Tested in a Laravel 12 project with Monolog 3.x.
- Verified that logs are correctly sent to Google Chat using the webhook URL.
- Ensured backward compatibility with Laravel 10/11 by keeping `illuminate/support ^10.0|^11.0`.

### How to Test
1. Install the package in a Laravel 12 project.
2. Configure the `google_chat` logging channel in `config/logging.php`.
3. Send a test log using `\Log::channel('google_chat')->info('Test message')`.
4. Verify that the message appears in the configured Google Chat space.
