### PR TITLE
Add repo hygiene: .gitattributes and community health files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,17 @@
-# Normalise line endings to LF in the repository.
-* text=auto eol=lf
+# Normalise line endings.
+* text=auto
 
-# Development and CI files, excluded from `composer require` dist archives.
-/.github            export-ignore
-/tests              export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/_config.yml        export-ignore
-/phpunit.xml        export-ignore
-/pint.json          export-ignore
-/CODE_OF_CONDUCT.md export-ignore
+# Exclude development & CI artifacts from the distributed Composer package.
+/.editorconfig       export-ignore
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+/.github             export-ignore
+/tests               export-ignore
+/phpunit.xml         export-ignore
+/pint.json           export-ignore
+/_config.yml         export-ignore
+/CHANGELOG.md        export-ignore
+/CONTRIBUTING.md     export-ignore
+/CODE_OF_CONDUCT.md  export-ignore
+/SECURITY.md         export-ignore
+/SUPPORT.md          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalise line endings to LF in the repository.
+* text=auto eol=lf
+
+# Development and CI files, excluded from `composer require` dist archives.
+/.github            export-ignore
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/_config.yml        export-ignore
+/phpunit.xml        export-ignore
+/pint.json          export-ignore
+/CODE_OF_CONDUCT.md export-ignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository.
+* @theriddleofenigma

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+A minimal code sample that reproduces the issue, e.g. your `google-chat`
+channel configuration and the log call that triggers the problem:
+
+```php
+// config/logging.php channel config (redact the webhook url!)
+
+// the log call
+Log::channel('google-chat')->error('...');
+```
+
+> :warning: **Never paste your webhook url.** It contains a `key` and `token`
+> that let anyone post to your space &mdash; redact them as `key=...&token=...`.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**What was sent / received**
+If relevant, the message that appeared in Google Chat (a screenshot is fine),
+or the HTTP response returned by the Chat API.
+
+**Environment**
+ - Package version: [e.g. 3.0.0]
+ - Laravel version: [e.g. 13.0.0]
+ - PHP version: [e.g. 8.4]
+
+**Additional context**
+Add any other context about the problem here (stack traces, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or support
+    url: https://github.com/theriddleofenigma/laravel-google-chat-log/discussions
+    about: Please ask and answer usage questions in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've
+considered.
+
+**Additional context**
+Add any other context or code samples about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Thanks for contributing! Please fill in the sections below and remove any that
+do not apply.
+-->
+
+## Description
+
+<!-- What does this PR do and why? Link any related issues, e.g. "Closes #123". -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behaviour)
+- [ ] Documentation update
+- [ ] Chore / maintenance (dependencies, CI, tooling)
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) guide.
+- [ ] The test suite passes locally (`composer test`).
+- [ ] I have added or updated tests that cover my changes.
+- [ ] I have updated the documentation where relevant.
+- [ ] I have updated the `CHANGELOG.md` under the "Unreleased" section.
+- [ ] No webhook urls, keys or tokens are included in the diff.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Thanks for taking the time to contribute! Contributions of all kinds are
+welcome &mdash; bug reports, feature requests, documentation, and code.
+
+## Code of Conduct
+
+This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold it. Please report unacceptable
+behaviour to the maintainer.
+
+## Reporting bugs & requesting features
+
+- Search the [existing issues](https://github.com/theriddleofenigma/laravel-google-chat-log/issues)
+  first to avoid duplicates.
+- Open a new issue using the appropriate template and include as much detail as
+  you can (a minimal reproduction goes a long way).
+- For usage questions, please use
+  [Discussions](https://github.com/theriddleofenigma/laravel-google-chat-log/discussions)
+  rather than the issue tracker.
+
+## Development setup
+
+This package targets **PHP 8.2+** and **Laravel 11 / 12 / 13**.
+
+```shell
+git clone https://github.com/theriddleofenigma/laravel-google-chat-log.git
+cd laravel-google-chat-log
+composer install
+```
+
+## Running the tests
+
+The suite uses [PHPUnit](https://phpunit.de/) and
+[Orchestra Testbench](https://github.com/orchestral/testbench):
+
+```shell
+composer test
+```
+
+Please make sure the whole suite passes and add coverage for any behaviour you
+change or add. The tests fake the HTTP client, so no real Google Chat webhook
+is needed to run them.
+
+## Coding style
+
+Code style is enforced with [Laravel Pint](https://laravel.com/docs/pint).
+Check and fix your changes before committing:
+
+```shell
+composer lint    # report style violations (used in CI)
+composer format  # fix them automatically
+```
+
+## Pull request guidelines
+
+1. Fork the repository and create your branch from `main`.
+2. Keep each pull request focused on a single concern.
+3. Follow the existing code style, enforced by Pint (`composer lint`).
+4. Add or update tests for your change.
+5. Update the documentation (`README.md`) and the `CHANGELOG.md` "Unreleased"
+   section where relevant.
+6. Ensure CI is green.
+
+## Reporting security issues
+
+Please do **not** open a public issue for security vulnerabilities. See
+[SECURITY.md](SECURITY.md) for how to report them privately.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,16 @@ Non-string values are JSON encoded automatically.
 ## Testing
 
 ```shell
-composer test
+composer test      # run the PHPUnit suite
+composer lint      # check code style with Laravel Pint
+composer format    # fix code style automatically
 ```
 
-This runs Laravel Pint (code style) and the PHPUnit suite.
+## Contributing
+
+Contributions are welcome &mdash; please read the
+[contributing guide](CONTRIBUTING.md) first. For security issues, see the
+[security policy](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest major release of the package running
+on a supported Laravel version (currently Laravel 11, 12 and 13).
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately rather than
+opening a public issue.
+
+- Preferred: use GitHub's
+  [private vulnerability reporting](https://github.com/theriddleofenigma/laravel-google-chat-log/security/advisories/new).
+- Alternatively, email **kumarwindows11@gmail.com** with the details.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Any suggested remediation, if you have one.
+
+You can expect an acknowledgement of your report, and we will keep you informed
+as the issue is investigated and resolved. Please give us a reasonable amount of
+time to address the issue before any public disclosure.
+
+## A note on webhook urls
+
+Google Chat incoming webhook urls contain a `key` and `token` and are
+credentials in their own right &mdash; anyone holding one can post to your
+space. Keep them in environment variables, never commit them, and redact them
+from logs, issue reports and reproductions before sharing.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+Thanks for using Laravel Google Chat Log! Here is how to get help.
+
+## Questions & usage help
+
+- Read the [README](README.md) &mdash; it covers installation, configuration
+  and every feature with examples.
+- Ask in [GitHub Discussions](https://github.com/theriddleofenigma/laravel-google-chat-log/discussions)
+  for how-to questions and general usage help.
+
+## Bugs & feature requests
+
+- Search the [existing issues](https://github.com/theriddleofenigma/laravel-google-chat-log/issues)
+  to see if it has already been reported.
+- If not, open a new issue using the appropriate template and include a minimal
+  reproduction.
+
+## Security issues
+
+Please report security vulnerabilities privately &mdash; see
+[SECURITY.md](SECURITY.md). Do not open a public issue for them.
+
+**Never paste a Google Chat webhook url** into an issue, discussion or
+reproduction. It contains a `key` and `token` that let anyone post to your
+space. Redact them as `key=...&token=...`.

--- a/composer.json
+++ b/composer.json
@@ -47,13 +47,10 @@
         }
     },
     "scripts": {
-        "lint": "pint",
-        "test:lint": "pint --test",
-        "test:unit": "phpunit",
-        "test": [
-            "@test:lint",
-            "@test:unit"
-        ]
+        "test": "vendor/bin/phpunit",
+        "test:coverage": "vendor/bin/phpunit --coverage-text",
+        "lint": "vendor/bin/pint --test",
+        "format": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Follow-up to #18. Brings this repository in line with the conventions used in [`laravel-model-validation`](https://github.com/theriddleofenigma/laravel-model-validation).

## 1. `.gitattributes` — keep dev files out of dist archives

Without one, `composer require` downloads the test suite, CI workflows and tooling config into every consumer's `vendor/` directory.

Verified with `git archive`. The dist archive now contains exactly:

```
LICENSE
README.md
composer.json
config/google-chat.php
src/GoogleChatHandler.php
src/GoogleChatLogServiceProvider.php
src/GoogleChatMessage.php
```

## 2. Community health files

Mirrored from `laravel-model-validation` so both packages behave the same:

| File | Purpose |
|---|---|
| `CONTRIBUTING.md` | Dev setup, tests, coding style, PR guidelines |
| `SECURITY.md` | Private vulnerability reporting |
| `SUPPORT.md` | Where to ask questions vs. file bugs |
| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug template |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature template |
| `.github/ISSUE_TEMPLATE/config.yml` | Routes questions to Discussions |
| `.github/CODEOWNERS` | Default reviewer |
| `.github/dependabot.yml` | Weekly composer + actions updates |
| `.editorconfig` | Editor defaults |

### Adapted for this package, not copied verbatim

- **Base branch is `main`**, not `master` — corrected in `CONTRIBUTING.md` and the PR template link.
- **PHP 8.2+ with Laravel 11/12/13**, matching this package's actual support matrix.
- **Webhook url safety.** Google Chat webhook urls embed a `key` and `token` and are credentials — anyone holding one can post to the space. The bug template, `SECURITY.md`, `SUPPORT.md` and the PR checklist all warn against pasting them into issues and reproductions.
- The bug template asks for the rendered Chat message / API response, which is what's actually diagnostic here.

## 3. Composer script alignment

Adopted the same script names as the other package, so muscle memory carries across:

```jsonc
"test":          "vendor/bin/phpunit"
"test:coverage": "vendor/bin/phpunit --coverage-text"
"lint":          "vendor/bin/pint --test"
"format":        "vendor/bin/pint"
```

> **Behaviour change:** `composer test` previously ran lint *and* tests; it now runs tests only, with `composer lint` separate. The README is updated to match. CI is unaffected — the workflows call `vendor/bin/phpunit` and `vendor/bin/pint --test` directly.

## Verification

- `composer validate --strict` — valid
- `composer test` — 17 tests / 27 assertions pass
- `composer lint` — clean
- `git archive` — confirmed dist contents above

No runtime code is touched.

## Note

`.github/ISSUE_TEMPLATE/config.yml` links to **Discussions**, which needs enabling in repo settings (Settings → Features → Discussions) or that link will 404. Same as the other package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkwAx1KkwkiJq7FzaWqsnj